### PR TITLE
Fix/alpha04 issues

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="pl.netigen.core" >
+        package="pl.netigen.core">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+
+        <activity
+                android:name="com.google.android.gms.ads.AdActivity"
+                android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
+                android:noHistory="true" />
+    </application>
 </manifest>

--- a/core/src/main/java/pl/netigen/core/ads/AdsManager.kt
+++ b/core/src/main/java/pl/netigen/core/ads/AdsManager.kt
@@ -77,7 +77,7 @@ class AdsManager(var viewModel: NetigenViewModel, val activity: AppCompatActivit
         rewardedAdManager?.showRewardedVideoForItems(rewardItems)
     }
 
-    fun reloadRewardedAd(){
+    fun reloadRewardedAd() {
         rewardedAdManager?.reloadAd()
     }
 

--- a/core/src/main/java/pl/netigen/core/ads/AdsManager.kt
+++ b/core/src/main/java/pl/netigen/core/ads/AdsManager.kt
@@ -56,12 +56,12 @@ class AdsManager(var viewModel: NetigenViewModel, val activity: AppCompatActivit
 
     fun loadRewardedVideoForAdId(rewardedAdId: String?) {
         if (rewardedAdManager == null) throw NullPointerException("Trying to load RewardedAd without initialization")
-        rewardedAdManager?.loadRewardedVideoForAdId(rewardedAdId)
+        rewardedAdManager?.loadIfNotLoadingForAdId(rewardedAdId)
     }
 
     fun loadRewardedVideo() {
         if (rewardedAdManager == null) throw NullPointerException("Trying to load RewardedAd without initialization")
-        rewardedAdManager?.loadRewardedVideo()
+        rewardedAdManager?.loadIfNotLoading()
     }
 
     fun resetCustomRewardedAdId() {
@@ -75,6 +75,10 @@ class AdsManager(var viewModel: NetigenViewModel, val activity: AppCompatActivit
             rewardedAdManager?.addListeners(it)
         }
         rewardedAdManager?.showRewardedVideoForItems(rewardItems)
+    }
+
+    fun reloadRewardedAd(){
+        rewardedAdManager?.reloadAd()
     }
 
     fun removeRewardedVideoCallbacks(listeners: RewardListenersList) {
@@ -94,37 +98,36 @@ class AdsManager(var viewModel: NetigenViewModel, val activity: AppCompatActivit
         val builder = AdRequest.Builder()
         if (viewModel.isInDebugMode()) {
             builder.addTestDevice("F1F415DDE480395A4D21C26D6C6A9619")
-                    .addTestDevice("9F65EEB1B6AED06CBE01CFEDA106BD29")
-                    .addTestDevice("0F4B0296B48D2C6478D7E9A89DDD07F8")
-                    .addTestDevice("593C1BC2C754805F5EFBCD8D4E288805")
-                    .addTestDevice("E4347B3256669EAB2235222F475C8492")
-                    .addTestDevice("0BFB00BFF8850BE0B8D40286BEDF317E")
-                    .addTestDevice("59E58CCD5AB9F4ED41033F114E088239")
-                    .addTestDevice("E42C3769BD763551CAC733B6AD662C0D")
-                    .addTestDevice("14D51CBB5AB10BDC1FF61BAECA19C9AA")
-                    .addTestDevice("8A575BCD3FC92B5719700193610FF48D")
-                    .addTestDevice("8B1306F1E7DBD7B656E55F89DFC222D7")
-                    .addTestDevice("3F520FF0CA7D49829C8E876C954D8E3D")
-                    .addTestDevice("CFB9B2A279566BB6577918A8A8C8F849")
-                    .addTestDevice("65364CA3C9CF87116F1D374660DF1235")
-                    .addTestDevice("209772FAC421F8EC3FF0D98B7A72FAD2")
-                    .addTestDevice("14D51CBB5AB10BDC1FF61BAECA19C9AA")
-                    .addTestDevice("3D1FCDD4B6DC7E453846A04D214FD12D")
-                    .addTestDevice("43AAFCE5A6B9E8FCDC58E58087AEC4EF")
-                    .addTestDevice("AD2180512DE8B1EE611AB4645A69E470")
-                    .addTestDevice("379BED7628AE4885B439939575F9F292")
+                .addTestDevice("9F65EEB1B6AED06CBE01CFEDA106BD29")
+                .addTestDevice("0F4B0296B48D2C6478D7E9A89DDD07F8")
+                .addTestDevice("593C1BC2C754805F5EFBCD8D4E288805")
+                .addTestDevice("E4347B3256669EAB2235222F475C8492")
+                .addTestDevice("0BFB00BFF8850BE0B8D40286BEDF317E")
+                .addTestDevice("59E58CCD5AB9F4ED41033F114E088239")
+                .addTestDevice("E42C3769BD763551CAC733B6AD662C0D")
+                .addTestDevice("14D51CBB5AB10BDC1FF61BAECA19C9AA")
+                .addTestDevice("8A575BCD3FC92B5719700193610FF48D")
+                .addTestDevice("8B1306F1E7DBD7B656E55F89DFC222D7")
+                .addTestDevice("3F520FF0CA7D49829C8E876C954D8E3D")
+                .addTestDevice("CFB9B2A279566BB6577918A8A8C8F849")
+                .addTestDevice("65364CA3C9CF87116F1D374660DF1235")
+                .addTestDevice("209772FAC421F8EC3FF0D98B7A72FAD2")
+                .addTestDevice("14D51CBB5AB10BDC1FF61BAECA19C9AA")
+                .addTestDevice("3D1FCDD4B6DC7E453846A04D214FD12D")
+                .addTestDevice("43AAFCE5A6B9E8FCDC58E58087AEC4EF")
+                .addTestDevice("AD2180512DE8B1EE611AB4645A69E470")
+                .addTestDevice("379BED7628AE4885B439939575F9F292")
 
             val testDevices = viewModel.getTestDevices()
             for (i in testDevices.indices) {
                 builder.addTestDevice(testDevices[i])
             }
-
         }
         if (ConsentInformation.getInstance(activity).consentStatus == ConsentStatus.NON_PERSONALIZED) {
             val extras = Bundle()
             extras.putString("npa", "1")
             return builder.addNetworkExtrasBundle(AdMobAdapter::class.java, extras)
-                    .build()
+                .build()
         }
 
         return builder.build()

--- a/core/src/main/java/pl/netigen/core/ads/BannerAdManager.kt
+++ b/core/src/main/java/pl/netigen/core/ads/BannerAdManager.kt
@@ -44,8 +44,9 @@ class BannerAdManager(var viewModel: NetigenViewModel, val activity: Activity, v
         }
         layout.addView(adView)
         val params = RelativeLayout.LayoutParams(
-                RelativeLayout.LayoutParams.MATCH_PARENT,
-                RelativeLayout.LayoutParams.WRAP_CONTENT)
+            RelativeLayout.LayoutParams.MATCH_PARENT,
+            RelativeLayout.LayoutParams.WRAP_CONTENT
+        )
         params.addRule(RelativeLayout.ALIGN_PARENT_TOP)
 
         adView?.layoutParams = params

--- a/core/src/main/java/pl/netigen/core/ads/InterstitialAdManager.kt
+++ b/core/src/main/java/pl/netigen/core/ads/InterstitialAdManager.kt
@@ -65,7 +65,7 @@ class InterstitialAdManager(private val viewModel: NetigenViewModel, val activit
     }
 
     private fun shouldShowAd(currentTime: Long) =
-            lastInterstitialAdDisplayTime == 0L || lastInterstitialAdDisplayTime + timeToDelayInterstitial < currentTime
+        lastInterstitialAdDisplayTime == 0L || lastInterstitialAdDisplayTime + timeToDelayInterstitial < currentTime
 
     private fun onNotLoaded(showInterstitialListener: ShowInterstitialListener) {
         showInterstitialListener.onShowedOrNotLoaded(false)
@@ -140,7 +140,7 @@ class InterstitialAdManager(private val viewModel: NetigenViewModel, val activit
         }
 
         private fun doesMaxLoadingTimeNotPassed() =
-                SystemClock.elapsedRealtime() - adLoadingStartTime < maxWaitForInterstitialAfterSplash
+            SystemClock.elapsedRealtime() - adLoadingStartTime < maxWaitForInterstitialAfterSplash
 
         private fun onAdLoading() {
             if (interstitialAdError) {
@@ -167,7 +167,7 @@ class InterstitialAdManager(private val viewModel: NetigenViewModel, val activit
         fun onShowedOrNotLoaded(success: Boolean)
     }
 
-    fun onDestroy(){
+    fun onDestroy() {
         interstitialAdHandler.removeCallbacksAndMessages(null)
     }
 

--- a/core/src/main/java/pl/netigen/core/ads/RewardedAd.kt
+++ b/core/src/main/java/pl/netigen/core/ads/RewardedAd.kt
@@ -146,4 +146,4 @@ class RewardedAd(var viewModel: NetigenViewModel, val activity: AppCompatActivit
     }
 }
 
-private val TAG = "RewardedAd"
+private const val TAG = "RewardedAd"

--- a/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
+++ b/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
@@ -1,6 +1,7 @@
 package pl.netigen.core.netigenapi
 
 import android.os.Bundle
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.widget.RelativeLayout
@@ -17,6 +18,7 @@ import pl.netigen.payments.PaymentManager
 import pl.netigen.payments.PurchaseListener
 
 abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActivity(), PurchaseListener {
+
     open lateinit var viewModel: ViewModel
     private lateinit var paymentManager: IPaymentManager
     private var bannerRelativeLayout: RelativeLayout? = null
@@ -31,6 +33,23 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         observeNoAds()
         if (viewModel.isDesignedForFamily) {
             onDesignForFamily()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.onStartActivity()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (viewModel.isNoAdsBought) {
+            hideBanner()
+        } else {
+            adsManager?.onResume(getBannerRelativeLayout())
+            if (viewModel.isDesignedForFamily) {
+                showBanner()
+            }
         }
     }
 
@@ -147,16 +166,8 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         paymentManager.initiatePurchase(viewModel.noAdsSku, this, this)
     }
 
-    override fun onResume() {
-        super.onResume()
-        if (viewModel.isNoAdsBought) {
-            hideBanner()
-        } else {
-            adsManager?.onResume(getBannerRelativeLayout())
-            if (viewModel.isDesignedForFamily) {
-                showBanner()
-            }
-        }
+    fun canCommitFragments(): Boolean {
+        return viewModel.canCommitFragments
     }
 
     override fun onPause() {
@@ -166,6 +177,11 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         }
     }
 
+    override fun onStop() {
+        super.onStop()
+        viewModel.onStopActivity()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         if (!viewModel.isNoAdsBought) {
@@ -173,4 +189,5 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         }
         paymentManager.onDestroy()
     }
+
 }

--- a/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
+++ b/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
@@ -57,6 +57,9 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         super.onRestoreInstanceState(savedInstanceState)
         if (adsManager == null && !viewModel.isNoAdsBought && consentInformation.consentStatus != ConsentStatus.UNKNOWN) {
             initAdsManager()
+            adsManager?.let{
+                it.rewardedAdManager?.reloadAd()
+            }
             showBanner()
         }
     }

--- a/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
+++ b/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
@@ -34,6 +34,14 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         }
     }
 
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        if (adsManager == null && !viewModel.isNoAdsBought && consentInformation.consentStatus != ConsentStatus.UNKNOWN) {
+            initAdsManager()
+            showBanner()
+        }
+    }
+
     private fun setConsentInformation() {
         consentInformation = ConsentInformation.getInstance(this)
     }
@@ -56,6 +64,7 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         initAdsManager()
         consentInformation.consentStatus = ConsentStatus.NON_PERSONALIZED
     }
+
     abstract fun hideAds()
 
     fun hideBanner() {

--- a/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
+++ b/core/src/main/java/pl/netigen/core/netigenapi/NetigenMainActivity.kt
@@ -1,7 +1,6 @@
 package pl.netigen.core.netigenapi
 
 import android.os.Bundle
-import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.widget.RelativeLayout
@@ -57,7 +56,7 @@ abstract class NetigenMainActivity<ViewModel : NetigenViewModel> : AppCompatActi
         super.onRestoreInstanceState(savedInstanceState)
         if (adsManager == null && !viewModel.isNoAdsBought && consentInformation.consentStatus != ConsentStatus.UNKNOWN) {
             initAdsManager()
-            adsManager?.let{
+            adsManager?.let {
                 it.rewardedAdManager?.reloadAd()
             }
             showBanner()

--- a/core/src/main/java/pl/netigen/core/netigenapi/NetigenSplashFragment.kt
+++ b/core/src/main/java/pl/netigen/core/netigenapi/NetigenSplashFragment.kt
@@ -12,7 +12,6 @@ import pl.netigen.gdpr.GDPRDialogFragment
 
 abstract class NetigenSplashFragment<ViewModel : NetigenViewModel> : Fragment(), GDPRDialogFragment.GDPRClickListener {
     private var consentNotShowed: Boolean = false
-    private var canCommitFragments: Boolean = false
     open lateinit var viewModel: ViewModel
     lateinit var netigenMainActivity: NetigenMainActivity<NetigenViewModel>
     private var gdprDialogFragment: GDPRDialogFragment? = null
@@ -50,16 +49,10 @@ abstract class NetigenSplashFragment<ViewModel : NetigenViewModel> : Fragment(),
 
     override fun onStart() {
         super.onStart()
-        canCommitFragments = true
         if (consentNotShowed) {
             onConsentInfoUpdated(netigenMainActivity)
             consentNotShowed = false
         }
-    }
-
-    override fun onStop() {
-        super.onStop()
-        canCommitFragments = false
     }
 
     private fun observeNoAds() {
@@ -105,7 +98,7 @@ abstract class NetigenSplashFragment<ViewModel : NetigenViewModel> : Fragment(),
 
         netigenMainActivity.consentInformation.requestConsentInfoUpdate(viewModel.publishersIds, object : ConsentInfoUpdateListener {
             override fun onConsentInfoUpdated(consentStatus: ConsentStatus) {
-                if (canCommitFragments) {
+                if (netigenMainActivity.canCommitFragments()) {
                     consentNotShowed = false
                     onConsentInfoUpdated(netigenMainActivity)
                 } else {

--- a/core/src/main/java/pl/netigen/core/netigenapi/NetigenViewModel.kt
+++ b/core/src/main/java/pl/netigen/core/netigenapi/NetigenViewModel.kt
@@ -16,13 +16,13 @@ abstract class NetigenViewModel(application: Application) : AndroidViewModel(app
     var noAdsLiveData = MutableLiveData<Boolean>()
     var delayBetweenInterstitialAds = 60L * 1000L
     open val noAdsSku: String
-            get() {
-                return if (config.inDebugMode) {
-                    PaymentManager.TEST_PURCHASED
-                } else {
-                    getApplication<Application>().packageName + ".noads"
-                }
+        get() {
+            return if (config.inDebugMode) {
+                PaymentManager.TEST_PURCHASED
+            } else {
+                getApplication<Application>().packageName + ".noads"
             }
+        }
 
     var isRewardedAdLoading: Boolean = false
     var isNoAdsPaymentAvailable: Boolean = config.isNoAdsPaymentAvailable
@@ -37,6 +37,17 @@ abstract class NetigenViewModel(application: Application) : AndroidViewModel(app
             config.isNoAdsBought = isNoAdsBought
             field = isNoAdsBought
         }
+
+    internal var canCommitFragments: Boolean = false
+        private set
+
+    fun onStartActivity() {
+        canCommitFragments = true
+    }
+
+    fun onStopActivity() {
+        canCommitFragments = false
+    }
 
     fun getInterstitialAdId() = config.interstitialAdId
     fun getRewardedAdId() = config.rewardedAdId


### PR DESCRIPTION
Fixes some admob issues:
-RewardedVideoAd showing black screen after restoring instance state
-InterstitialAd shown multiple times when restoring instance state 

Moves canCommitFragment logic to Activity, it should be used as a condition to show a dialogFragments, when show is done from async call - like in GDPRDialogFragment with ConsentInformation. Should also be used if you want to make sure that you won't try to show dialogFragment outside of onStart()->onStop() scope

Fixes #89 